### PR TITLE
Add mechanism for supporting multiple simulators for tests

### DIFF
--- a/verilog/dv/caravel/common/icarus.mk
+++ b/verilog/dv/caravel/common/icarus.mk
@@ -1,0 +1,18 @@
+#****************************************************************************
+#* Sim support makefile for Icarus Verilog
+#*
+#* Variables:
+#* - INCDIRS - List of include-path directories
+#****************************************************************************
+
+%.vpp : %_tb.v %.hex
+	iverilog $(foreach def,$(DEFINES),-D$(def)) \
+		$(foreach inc,$(INCDIRS),-I $(inc)) \
+		$< -o $@
+
+%.vcd : %.vpp
+	vvp $<
+
+clean ::
+	rm -f *.vpp
+

--- a/verilog/dv/caravel/common/questa.mk
+++ b/verilog/dv/caravel/common/questa.mk
@@ -1,0 +1,30 @@
+#****************************************************************************
+#* Sim support makefile for Icarus Verilog
+#*
+#* Variables:
+#* - INCDIRS - List of include-path directories
+#* - DEFINES - List of definitions
+#****************************************************************************
+
+VLOG_SUPPRESS = 2388,2248,2892
+#VLOG_SUPPRESS = 2388
+#VLOG_SUPPRESS = 2388,2892
+#VLOG_SUPPRESS = 2248,2892
+#VOPT_SUPPRESS = -suppress 3013
+
+%.questa : %_tb.v %.hex
+	vlog $(foreach def,$(DEFINES), +define+$(def)) \
+		$(foreach inc,$(INCDIRS),+incdir+$(inc)) \
+		-suppress $(VLOG_SUPPRESS) \
+		$<
+	vopt -debug -o $(*)_tb_opt $(*)_tb $(VOPT_SUPPRESS) +designfile
+	touch $@
+
+
+%.vcd : %.questa
+	vsim -batch -do "run -a; quit -f" $(*)_tb_opt \
+		-qwavedb=+report=class+signal
+
+clean ::
+	rm -rf transcript work *.questa design.bin qwave.db
+

--- a/verilog/dv/caravel/common/questa.mk
+++ b/verilog/dv/caravel/common/questa.mk
@@ -1,5 +1,5 @@
 #****************************************************************************
-#* Sim support makefile for Icarus Verilog
+#* Sim support makefile for Mentor Questa
 #*
 #* Variables:
 #* - INCDIRS - List of include-path directories
@@ -27,4 +27,3 @@ VLOG_SUPPRESS = 2388,2248,2892
 
 clean ::
 	rm -rf transcript work *.questa design.bin qwave.db
-

--- a/verilog/dv/caravel/mgmt_soc/gpio/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/gpio/Makefile
@@ -5,6 +5,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -14,13 +15,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -35,8 +31,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/mgmt_soc/hkspi/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/hkspi/Makefile
@@ -6,6 +6,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -15,13 +16,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -36,8 +32,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/mgmt_soc/mem/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/mem/Makefile
@@ -6,6 +6,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -15,13 +16,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -36,8 +32,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/mgmt_soc/mprj_ctrl/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/mprj_ctrl/Makefile
@@ -6,6 +6,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -15,13 +16,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -36,8 +32,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/mgmt_soc/pass_thru/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/pass_thru/Makefile
@@ -6,6 +6,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -15,13 +16,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -36,8 +32,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/mgmt_soc/perf/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/perf/Makefile
@@ -5,6 +5,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -14,13 +15,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-	
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -36,8 +32,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/mgmt_soc/pll/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/pll/Makefile
@@ -5,6 +5,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -14,13 +15,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(PDK_PATH) -I $(BEHAVIOURAL_MODELS) \
-	-I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -35,8 +31,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/mgmt_soc/storage/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/storage/Makefile
@@ -5,6 +5,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -14,13 +15,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(PDK_PATH) -I $(BEHAVIOURAL_MODELS) \
-	-I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -35,8 +31,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/mgmt_soc/sysctrl/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/sysctrl/Makefile
@@ -5,6 +5,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -14,13 +15,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -35,8 +31,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/mgmt_soc/timer/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/timer/Makefile
@@ -5,6 +5,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -14,13 +15,9 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
-%.vcd: %.vvp
-	vvp $<
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -35,8 +32,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
-	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
+clean::
+	rm -f *.elf *.hex *.bin *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/mgmt_soc/timer2/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/timer2/Makefile
@@ -5,6 +5,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -14,13 +15,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -Wall -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -35,8 +31,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/mgmt_soc/uart/Makefile
+++ b/verilog/dv/caravel/mgmt_soc/uart/Makefile
@@ -6,6 +6,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -15,13 +16,9 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
-%.vcd: %.vvp
-	vvp $<
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -36,8 +33,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
 

--- a/verilog/dv/caravel/user_proj_example/io_ports/Makefile
+++ b/verilog/dv/caravel/user_proj_example/io_ports/Makefile
@@ -5,6 +5,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -14,13 +15,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -35,7 +31,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
+

--- a/verilog/dv/caravel/user_proj_example/la_test1/Makefile
+++ b/verilog/dv/caravel/user_proj_example/la_test1/Makefile
@@ -5,6 +5,7 @@ BEHAVIOURAL_MODELS = ../../
 
 GCC_PATH?=/ef/apps/bin
 PDK_PATH?=/ef/tech/SW/sky130A
+SIM?=icarus
 
 .SUFFIXES:
 
@@ -14,13 +15,8 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
-%.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
-	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
+DEFINES += FUNCTIONAL
+INCDIRS += $(BEHAVIOURAL_MODELS) $(PDK_PATH) $(IP_PATH) $(RTL_PATH)
 
 %.elf: %.c $(FIRMWARE_PATH)/sections.lds $(FIRMWARE_PATH)/start.s
 	${GCC_PATH}/riscv32-unknown-elf-gcc -march=rv32imc -Wl,-Bstatic,-T,$(FIRMWARE_PATH)/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(FIRMWARE_PATH)/start.s $<
@@ -35,7 +31,11 @@ hex:  ${PATTERN:=.hex}
 
 # ---- Clean ----
 
-clean:
+clean::
 	rm -f *.elf *.hex *.bin *.vvp *.vcd *.log
 
 .PHONY: clean hex all
+
+# Bring in simulator-specific rules
+include ../../common/$(SIM).mk
+

--- a/verilog/dv/wb_utests/common/icarus.mk
+++ b/verilog/dv/wb_utests/common/icarus.mk
@@ -1,0 +1,18 @@
+#****************************************************************************
+#* Sim support makefile for Icarus Verilog
+#*
+#* Variables:
+#* - INCDIRS - List of include-path directories
+#****************************************************************************
+
+%.vpp : %_tb.v
+	iverilog $(foreach def,$(DEFINES),-D$(def)) \
+		$(foreach inc,$(INCDIRS),-I $(inc)) \
+		$< -o $@
+
+%.vcd : %.vpp
+	vvp $<
+
+clean ::
+	rm -f *.vpp
+

--- a/verilog/dv/wb_utests/common/questa.mk
+++ b/verilog/dv/wb_utests/common/questa.mk
@@ -1,0 +1,30 @@
+#****************************************************************************
+#* Sim support makefile for Icarus Verilog
+#*
+#* Variables:
+#* - INCDIRS - List of include-path directories
+#* - DEFINES - List of definitions
+#****************************************************************************
+
+VLOG_SUPPRESS = 2388,2248,2892
+#VLOG_SUPPRESS = 2388
+#VLOG_SUPPRESS = 2388,2892
+#VLOG_SUPPRESS = 2248,2892
+#VOPT_SUPPRESS = -suppress 3013
+
+%.questa : %_tb.v %.hex
+	vlog $(foreach def,$(DEFINES), +define+$(def)) \
+		$(foreach inc,$(INCDIRS),+incdir+$(inc)) \
+		-suppress $(VLOG_SUPPRESS) \
+		$<
+	vopt -debug -o $(*)_tb_opt $(*)_tb $(VOPT_SUPPRESS) +designfile
+	touch $@
+
+
+%.vcd : %.questa
+	vsim -batch -do "run -a; quit -f" $(*)_tb_opt \
+		-qwavedb=+report=class+signal
+
+clean ::
+	rm -rf transcript work *.questa design.bin qwave.db
+

--- a/verilog/dv/wb_utests/common/questa.mk
+++ b/verilog/dv/wb_utests/common/questa.mk
@@ -1,5 +1,5 @@
 #****************************************************************************
-#* Sim support makefile for Icarus Verilog
+#* Sim support makefile for Mentor Questa
 #*
 #* Variables:
 #* - INCDIRS - List of include-path directories
@@ -27,4 +27,3 @@ VLOG_SUPPRESS = 2388,2248,2892
 
 clean ::
 	rm -rf transcript work *.questa design.bin qwave.db
-

--- a/verilog/dv/wb_utests/gpio_wb/Makefile
+++ b/verilog/dv/wb_utests/gpio_wb/Makefile
@@ -1,17 +1,17 @@
 .SUFFIXES:
 
 PATTERN = gpio_wb
+SIM?=icarus
 
 all:  ${PATTERN:=.vcd}
 
-%.vvp: %_tb.v
-	iverilog -I .. -I ../../../rtl \
-	$< -o $@
+INCDIRS += ../ ../../../rtl
 
-%.vcd: %.vvp
-	vvp $<
-
-clean:
+clean::
 	rm -f *.vvp *.vcd
 
 .PHONY: clean all
+
+# Bring in sim-specific rules
+include ../common/$(SIM).mk
+

--- a/verilog/dv/wb_utests/intercon_wb/Makefile
+++ b/verilog/dv/wb_utests/intercon_wb/Makefile
@@ -1,17 +1,16 @@
 .SUFFIXES:
 
 PATTERN = intercon_wb
+SIM?=icarus
+INCDIRS += ../ ../../ ../../../rtl
 
 all:  ${PATTERN:=.vcd}
 
-%.vvp: %_tb.v
-	iverilog -I .. -I ../../ -I ../../../rtl \
-	$< -o $@
 
-%.vcd: %.vvp
-	vvp $<
-
-clean:
+clean::
 	rm -f *.vvp *.vcd *.log
 
 .PHONY: clean all
+
+# Bring in sim-specific rules
+include ../common/$(SIM).mk

--- a/verilog/dv/wb_utests/la_wb/Makefile
+++ b/verilog/dv/wb_utests/la_wb/Makefile
@@ -1,17 +1,16 @@
 .SUFFIXES:
 
 PATTERN = la_wb
+SIM?=icarus
+INCDIRS += ../ ../../../rtl
 
 all:  ${PATTERN:=.vcd}
 
-%.vvp: %_tb.v
-	iverilog -I .. -I ../../../rtl \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
-
-clean:
+clean::
 	rm -f *.vvp *.vcd
 
 .PHONY: clean all
+
+# Bring in sim-specific rules
+include ../common/$(SIM).mk
+

--- a/verilog/dv/wb_utests/mem_wb/Makefile
+++ b/verilog/dv/wb_utests/mem_wb/Makefile
@@ -1,17 +1,17 @@
 .SUFFIXES:
 
 PATTERN = mem_wb
+SIM?=icarus
+INCDIRS += ../ ../../ ../../../rtl
 
 all:  ${PATTERN:=.vcd}
 
-%.vvp: %_tb.v
-	iverilog -I .. -I ../../../rtl \
-	$< -o $@
 
-%.vcd: %.vvp
-	vvp $<
-
-clean:
+clean::
 	rm -f *.vvp *.vcd
 
 .PHONY: clean all
+
+# Bring in sim-specific rules
+include ../common/$(SIM).mk
+

--- a/verilog/dv/wb_utests/mprj_ctrl/Makefile
+++ b/verilog/dv/wb_utests/mprj_ctrl/Makefile
@@ -1,17 +1,16 @@
 .SUFFIXES:
 
 PATTERN = mprj_ctrl
+SIM?=icarus
+INCDIRS += ../ ../../ ../../../rtl
 
 all:  ${PATTERN:=.vcd}
 
-%.vvp: %_tb.v
-	iverilog  -I ../../../rtl \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
-
-clean:
+clean::
 	rm -f *.vvp *.vcd *.log
 
 .PHONY: clean all
+
+# Bring in sim-specific rules
+include ../common/$(SIM).mk
+

--- a/verilog/dv/wb_utests/spi_sysctrl_wb/Makefile
+++ b/verilog/dv/wb_utests/spi_sysctrl_wb/Makefile
@@ -1,18 +1,16 @@
 .SUFFIXES:
 
 PATTERN = spi_sysctrl_wb
+SIM?=icarus
+INCDIRS += ../ ../../../rtl
 
 all:  ${PATTERN:=.vcd}
 
-%.vvp: %_tb.v
-	iverilog  -I ../../../rtl \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
-
-clean:
+clean::
 	rm -f *.vvp *.vcd *.log
 
 .PHONY: clean all
+
+# Bring in sim-specific rules
+include ../common/$(SIM).mk
 

--- a/verilog/dv/wb_utests/spimemio_wb/Makefile
+++ b/verilog/dv/wb_utests/spimemio_wb/Makefile
@@ -1,18 +1,16 @@
 .SUFFIXES:
 
 PATTERN = spimemio_wb
+SIM?=icarus
+INCDIRS += ../ ../../ ../../../rtl
 
 all:  ${PATTERN:=.vcd}
 
-%.vvp: %_tb.v
-	iverilog -I ../ -I ../../  -I ../../../rtl \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
-
-clean:
+clean::
 	rm -f *.vvp *.vcd *.log
 
 .PHONY: clean all
+
+# Bring in sim-specific rules
+include ../common/$(SIM).mk
 

--- a/verilog/dv/wb_utests/storage_wb/Makefile
+++ b/verilog/dv/wb_utests/storage_wb/Makefile
@@ -1,17 +1,16 @@
 .SUFFIXES:
 
 PATTERN = storage_wb
+SIM?=icarus
+INCDIRS += ../ ../../../rtl
 
 all:  ${PATTERN:=.vcd}
 
-%.vvp: %_tb.v
-	iverilog  -I ../../../rtl \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
-
-clean:
+clean::
 	rm -f *.vvp *.vcd *.log
 
 .PHONY: clean all
+
+# Bring in sim-specific rules
+include ../common/$(SIM).mk
+

--- a/verilog/dv/wb_utests/sysctrl_wb/Makefile
+++ b/verilog/dv/wb_utests/sysctrl_wb/Makefile
@@ -1,18 +1,16 @@
 .SUFFIXES:
 
 PATTERN = sysctrl_wb
+SIM?=icarus
+INCDIRS += ../ ../../../rtl
 
 all:  ${PATTERN:=.vcd}
 
-%.vvp: %_tb.v
-	iverilog  -I ../../../rtl \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
-
-clean:
+clean::
 	rm -f *.vvp *.vcd *.log
 
 .PHONY: clean all
+
+# Bring in sim-specific rules
+include ../common/$(SIM).mk
 

--- a/verilog/dv/wb_utests/uart_wb/Makefile
+++ b/verilog/dv/wb_utests/uart_wb/Makefile
@@ -1,17 +1,16 @@
 .SUFFIXES:
 
 PATTERN = uart_wb
+SIM?=icarus
+INCDIRS += ../ ../../ ../../../rtl
 
 all:  ${PATTERN:=.vcd}
 
-%.vvp: %_tb.v
-	iverilog -I .. -I ../../ -I ../../../rtl \
-	$< -o $@
-
-%.vcd: %.vvp
-	vvp $<
-
-clean:
+clean::
 	rm -f *.vvp *.vcd *.log
 
 .PHONY: clean all
+
+# Bring in sim-specific rules
+include ../common/$(SIM).mk
+


### PR DESCRIPTION
The caravel tests currently support Icarus Verilog as a simulator. I've updated the Makefiles to support multiple simulators by setting SIM=<simulator>. The Makefiles default to SIM=icarus, so no change is required in how the tests are run.
This PR adds a starting-point file to support the Questa simulator. 

Signed-off-by: Matthew Ballance <matt.ballance@gmail.com>