### PR TITLE
Various testbench fixes (missing power nets, iverilog params, prefixes)

### DIFF
--- a/verilog/dv/caravel/user_proj_example/io_ports/Makefile
+++ b/verilog/dv/caravel/user_proj_example/io_ports/Makefile
@@ -3,12 +3,9 @@ RTL_PATH = ../../../../rtl
 IP_PATH = ../../../../ip
 BEHAVIOURAL_MODELS = ../../ 
 
-GCC_PATH?=/Users/dan.rodrigues/opt/riscv-none-embed-gcc/8.3.0-1.1/bin
-# GCC_PREFIX?=riscv32-unknown-elf
-# PDK_PATH?=/ef/tech/SW/sky130A
-
-GCC_PREFIX=riscv-none-embed
-PDK_PATH?=/Users/dan.rodrigues/hw/sky130A
+GCC_PATH?=/ef/apps/bin
+GCC_PREFIX?=riscv32-unknown-elf
+PDK_PATH?=/ef/tech/SW/sky130A
 
 .SUFFIXES:
 
@@ -32,7 +29,7 @@ hex:  ${PATTERN:=.hex}
 %.hex: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O verilog $< $@ 
 	# to fix flash base address
-	gsed -i 's/@10000000/@00000000/g' $@
+	sed -i 's/@10000000/@00000000/g' $@
 
 %.bin: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O binary $< /dev/stdout | tail -c +1048577 > $@

--- a/verilog/dv/caravel/user_proj_example/io_ports/Makefile
+++ b/verilog/dv/caravel/user_proj_example/io_ports/Makefile
@@ -3,9 +3,12 @@ RTL_PATH = ../../../../rtl
 IP_PATH = ../../../../ip
 BEHAVIOURAL_MODELS = ../../ 
 
-GCC_PATH?=/ef/apps/bin
-GCC_PREFIX?=riscv32-unknown-elf
-PDK_PATH?=/ef/tech/SW/sky130A
+GCC_PATH?=/Users/dan.rodrigues/opt/riscv-none-embed-gcc/8.3.0-1.1/bin
+# GCC_PREFIX?=riscv32-unknown-elf
+# PDK_PATH?=/ef/tech/SW/sky130A
+
+GCC_PREFIX=riscv-none-embed
+PDK_PATH?=/Users/dan.rodrigues/hw/sky130A
 
 .SUFFIXES:
 
@@ -18,7 +21,7 @@ hex:  ${PATTERN:=.hex}
 %.vvp: %_tb.v %.hex
 	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
 	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
+	-o $@ $<
 
 %.vcd: %.vvp
 	vvp $<
@@ -29,7 +32,7 @@ hex:  ${PATTERN:=.hex}
 %.hex: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O verilog $< $@ 
 	# to fix flash base address
-	sed -i 's/@10000000/@00000000/g' $@
+	gsed -i 's/@10000000/@00000000/g' $@
 
 %.bin: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O binary $< /dev/stdout | tail -c +1048577 > $@

--- a/verilog/dv/caravel/user_proj_example/io_ports/io_ports_tb.v
+++ b/verilog/dv/caravel/user_proj_example/io_ports/io_ports_tb.v
@@ -86,22 +86,16 @@ module io_ports_tb;
 		#1 $display("MPRJ-IO state = %b ", mprj_io[7:0]);
 	end
 
-    	wire flash_csb;
+	wire flash_csb;
 	wire flash_clk;
 	wire flash_io0;
 	wire flash_io1;
 
-	wire USER_VDD1V8;
-	wire USER_VDD3V3;
-	wire VDD1V8;
-    	wire VDD3V3;
-	wire VSS;
-    
-	assign VDD3V3 = power1;
-	assign VDD1V8 = power2;
-	assign USER_VDD3V3 = power3;
-	assign USER_VDD1V8 = power4;
-	assign VSS = 1'b0;
+	wire VDD3V3 = power1;
+	wire VDD1V8 = power2;
+	wire USER_VDD3V3 = power3;
+	wire USER_VDD1V8 = power4;
+	wire VSS = 1'b0;
 
 	caravel uut (
 		.vddio	  (VDD3V3),

--- a/verilog/dv/caravel/user_proj_example/la_test1/Makefile
+++ b/verilog/dv/caravel/user_proj_example/la_test1/Makefile
@@ -3,12 +3,9 @@ RTL_PATH = ../../../../rtl
 IP_PATH = ../../../../ip
 BEHAVIOURAL_MODELS = ../../ 
 
-GCC_PATH?=/Users/dan.rodrigues/opt/riscv-none-embed-gcc/8.3.0-1.1/bin
-# GCC_PREFIX?=riscv32-unknown-elf
-# PDK_PATH?=/ef/tech/SW/sky130A
-
-GCC_PREFIX=riscv-none-embed
-PDK_PATH?=/Users/dan.rodrigues/hw/sky130A
+GCC_PATH?=/ef/apps/bin
+GCC_PREFIX?=riscv32-unknown-elf
+PDK_PATH?=/ef/tech/SW/sky130A
 
 .SUFFIXES:
 
@@ -32,7 +29,7 @@ hex:  ${PATTERN:=.hex}
 %.hex: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O verilog $< $@ 
 	# to fix flash base address
-	gsed -i 's/@10000000/@00000000/g' $@
+	sed -i 's/@10000000/@00000000/g' $@
 
 %.bin: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O binary $< /dev/stdout | tail -c +1048577 > $@

--- a/verilog/dv/caravel/user_proj_example/la_test1/Makefile
+++ b/verilog/dv/caravel/user_proj_example/la_test1/Makefile
@@ -3,9 +3,12 @@ RTL_PATH = ../../../../rtl
 IP_PATH = ../../../../ip
 BEHAVIOURAL_MODELS = ../../ 
 
-GCC_PATH?=/ef/apps/bin
-GCC_PREFIX?=riscv32-unknown-elf
-PDK_PATH?=/ef/tech/SW/sky130A
+GCC_PATH?=/Users/dan.rodrigues/opt/riscv-none-embed-gcc/8.3.0-1.1/bin
+# GCC_PREFIX?=riscv32-unknown-elf
+# PDK_PATH?=/ef/tech/SW/sky130A
+
+GCC_PREFIX=riscv-none-embed
+PDK_PATH?=/Users/dan.rodrigues/hw/sky130A
 
 .SUFFIXES:
 
@@ -18,7 +21,7 @@ hex:  ${PATTERN:=.hex}
 %.vvp: %_tb.v %.hex
 	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
 	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
+	-o $@ $<
 
 %.vcd: %.vvp
 	vvp $<
@@ -29,7 +32,7 @@ hex:  ${PATTERN:=.hex}
 %.hex: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O verilog $< $@ 
 	# to fix flash base address
-	sed -i 's/@10000000/@00000000/g' $@
+	gsed -i 's/@10000000/@00000000/g' $@
 
 %.bin: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O binary $< /dev/stdout | tail -c +1048577 > $@

--- a/verilog/dv/caravel/user_proj_example/la_test2/Makefile
+++ b/verilog/dv/caravel/user_proj_example/la_test2/Makefile
@@ -3,12 +3,9 @@ RTL_PATH = ../../../../rtl
 IP_PATH = ../../../../ip
 BEHAVIOURAL_MODELS = ../../ 
 
-GCC_PATH?=/Users/dan.rodrigues/opt/riscv-none-embed-gcc/8.3.0-1.1/bin
-# GCC_PREFIX?=riscv32-unknown-elf
-# PDK_PATH?=/ef/tech/SW/sky130A
-
-GCC_PREFIX=riscv-none-embed
-PDK_PATH?=/Users/dan.rodrigues/hw/sky130A
+GCC_PATH?=/ef/apps/bin
+GCC_PREFIX?=riscv32-unknown-elf
+PDK_PATH?=/ef/tech/SW/sky130A
 
 .SUFFIXES:
 
@@ -32,7 +29,7 @@ hex:  ${PATTERN:=.hex}
 %.hex: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O verilog $< $@ 
 	# to fix flash base address
-	gsed -i 's/@10000000/@00000000/g' $@
+	sed -i 's/@10000000/@00000000/g' $@
 
 %.bin: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O binary $< /dev/stdout | tail -c +1048577 > $@

--- a/verilog/dv/caravel/user_proj_example/la_test2/Makefile
+++ b/verilog/dv/caravel/user_proj_example/la_test2/Makefile
@@ -3,9 +3,12 @@ RTL_PATH = ../../../../rtl
 IP_PATH = ../../../../ip
 BEHAVIOURAL_MODELS = ../../ 
 
-GCC_PATH?=/ef/apps/bin
-GCC_PREFIX?=riscv32-unknown-elf
-PDK_PATH?=/ef/tech/SW/sky130A
+GCC_PATH?=/Users/dan.rodrigues/opt/riscv-none-embed-gcc/8.3.0-1.1/bin
+# GCC_PREFIX?=riscv32-unknown-elf
+# PDK_PATH?=/ef/tech/SW/sky130A
+
+GCC_PREFIX=riscv-none-embed
+PDK_PATH?=/Users/dan.rodrigues/hw/sky130A
 
 .SUFFIXES:
 
@@ -18,7 +21,7 @@ hex:  ${PATTERN:=.hex}
 %.vvp: %_tb.v %.hex
 	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
 	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
-	$< -o $@
+	-o $@ $<
 
 %.vcd: %.vvp
 	vvp $<
@@ -29,7 +32,7 @@ hex:  ${PATTERN:=.hex}
 %.hex: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O verilog $< $@ 
 	# to fix flash base address
-	sed -i 's/@10000000/@00000000/g' $@
+	gsed -i 's/@10000000/@00000000/g' $@
 
 %.bin: %.elf
 	${GCC_PATH}/${GCC_PREFIX}-objcopy -O binary $< /dev/stdout | tail -c +1048577 > $@


### PR DESCRIPTION
* Some power nets were undeclared in `io_ports_tb.v` which caused issues with `defaultnettype none`
* Some of the GCC prefixes were doubled up in certain Makefiles
* The `-o` param in the iverilog invocation was reversed, causing an error like this:

```
-o: No such file or directory
```

The sims build and pass locally with these changes.