### PR TITLE
Add flash-spoof mode to make large management-core programs run faster

### DIFF
--- a/verilog/dv/caravel/user_proj_example/io_ports/Makefile
+++ b/verilog/dv/caravel/user_proj_example/io_ports/Makefile
@@ -7,6 +7,8 @@ GCC_PATH?=/ef/apps/bin
 GCC_PREFIX?=riscv32-unknown-elf
 PDK_PATH?=/ef/tech/SW/sky130A
 
+SPOOF_FAST_FLASH=
+
 .SUFFIXES:
 
 PATTERN = io_ports
@@ -15,8 +17,9 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
+spoof_var := $(if $(SPOOF_FAST_FLASH),-DSPOOF_FAST_FLASH=\"$(PATTERN).hex\",)
 %.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
+	iverilog $(spoof_var) -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
 	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
 	-o $@ $<
 

--- a/verilog/dv/caravel/user_proj_example/la_test1/Makefile
+++ b/verilog/dv/caravel/user_proj_example/la_test1/Makefile
@@ -7,6 +7,8 @@ GCC_PATH?=/ef/apps/bin
 GCC_PREFIX?=riscv32-unknown-elf
 PDK_PATH?=/ef/tech/SW/sky130A
 
+SPOOF_FAST_FLASH=
+
 .SUFFIXES:
 
 PATTERN = la_test1
@@ -15,8 +17,9 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
+spoof_var := $(if $(SPOOF_FAST_FLASH),-DSPOOF_FAST_FLASH=\"$(PATTERN).hex\",)
 %.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
+	iverilog $(spoof_var) -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
 	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
 	-o $@ $<
 

--- a/verilog/dv/caravel/user_proj_example/la_test2/Makefile
+++ b/verilog/dv/caravel/user_proj_example/la_test2/Makefile
@@ -7,6 +7,8 @@ GCC_PATH?=/ef/apps/bin
 GCC_PREFIX?=riscv32-unknown-elf
 PDK_PATH?=/ef/tech/SW/sky130A
 
+SPOOF_FAST_FLASH=
+
 .SUFFIXES:
 
 PATTERN = la_test2
@@ -15,8 +17,9 @@ all:  ${PATTERN:=.vcd}
 
 hex:  ${PATTERN:=.hex}
 
+spoof_var := $(if $(SPOOF_FAST_FLASH),-DSPOOF_FAST_FLASH=\"$(PATTERN).hex\",)
 %.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
+	iverilog $(spoof_var) -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
 	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
 	-o $@ $<
 


### PR DESCRIPTION
Add flash-spoof mode to make large management-core programs run faster by directly responding to wishbone requests with data from memory hex file. Enable by passing 'SPOOF_FAST_FLASH=1' to 'io_ports' / 'la_test1' / 'la_test2'.

(Added this to make it easier to do quick iterations on my user-project and thought it might be useful to add upstream)