### PR TITLE
Minor RTL fixes, switching to wrapped GPIOV2

### DIFF
--- a/verilog/rtl/caravel.v
+++ b/verilog/rtl/caravel.v
@@ -23,6 +23,7 @@
 
 `include "libs.ref/sky130_fd_io/verilog/sky130_fd_io.v"
 `include "libs.ref/sky130_fd_io/verilog/sky130_ef_io.v"
+`include "libs.tech/openlane/custom_cells/verilog/sky130_ef_io__gpiov2_pad_wrapped.v"
 
 `include "libs.ref/sky130_fd_sc_hd/verilog/primitives.v"
 `include "libs.ref/sky130_fd_sc_hd/verilog/sky130_fd_sc_hd.v"
@@ -181,8 +182,8 @@ module caravel (
     // irq 	 = mprj_io[7]		(input)
 
     wire [`MPRJ_IO_PADS-1:0] mgmt_io_in;
-    wire jtag_out, sdo_out; 		
-    wire jtag_outenb, sdo_outenb; 
+    wire jtag_out, sdo_out;
+    wire jtag_outenb, sdo_outenb;
 
     wire [`MPRJ_IO_PADS-3:0] mgmt_io_nc1;	/* no-connects */
     wire [`MPRJ_IO_PADS-3:0] mgmt_io_nc3;	/* no-connects */
@@ -340,15 +341,15 @@ module caravel (
 	wire	    mprj2_vdd_pwrgood;
 
 	// Storage area
-	// Management R/W interface 
-	wire [`RAM_BLOCKS-1:0] mgmt_ena; 
+	// Management R/W interface
+	wire [`RAM_BLOCKS-1:0] mgmt_ena;
     wire [`RAM_BLOCKS-1:0] mgmt_wen;
     wire [(`RAM_BLOCKS*4)-1:0] mgmt_wen_mask;
     wire [7:0] mgmt_addr;
     wire [31:0] mgmt_wdata;
     wire [(`RAM_BLOCKS*32)-1:0] mgmt_rdata;
 	// Management RO interface
-	wire mgmt_ena_ro; 
+	wire mgmt_ena_ro;
     wire [7:0] mgmt_addr_ro;
     wire [31:0] mgmt_rdata_ro;
 
@@ -387,7 +388,7 @@ module caravel (
         	.core_clk(caravel_clk),
         	.user_clk(caravel_clk2),
         	.core_rstn(caravel_rstn),
-		// Logic Analyzer 
+		// Logic Analyzer
 		.la_input(la_data_in_mprj),
 		.la_output(la_data_out_mprj),
 		.la_oen(la_oen_mprj),
@@ -417,8 +418,8 @@ module caravel (
 		.mprj_dat_i(mprj_dat_i_core),
 		// mask data
 		.mask_rev(mask_rev),
-		// MGMT area R/W interface 
-    	.mgmt_ena(mgmt_ena), 
+		// MGMT area R/W interface
+    	.mgmt_ena(mgmt_ena),
     	.mgmt_wen_mask(mgmt_wen_mask),
     	.mgmt_wen(mgmt_wen),
     	.mgmt_addr(mgmt_addr),
@@ -477,12 +478,13 @@ module caravel (
 		.user2_vdd_powergood(mprj2_vdd_pwrgood)
 	);
 
-	
+
 	/*----------------------------------------------*/
 	/* Wrapper module around the user project 	*/
 	/*----------------------------------------------*/
 
-	user_project_wrapper mprj ( 
+	user_project_wrapper mprj (
+    	`ifdef USE_POWER_PINS
 		.vdda1(vdda1),	// User area 1 3.3V power
 		.vdda2(vdda2),	// User area 2 3.3V power
 		.vssa1(vssa1),	// User area 1 analog ground
@@ -491,10 +493,11 @@ module caravel (
 		.vccd2(vccd2),	// User area 2 1.8V power
 		.vssd1(vssd1),	// User area 1 digital ground
 		.vssd2(vssd2),	// User area 2 digital ground
+        `endif
 
     		.wb_clk_i(mprj_clock),
     		.wb_rst_i(mprj_reset),
-		// MGMT SoC Wishbone Slave 
+		// MGMT SoC Wishbone Slave
 		.wbs_cyc_i(mprj_cyc_o_user),
 		.wbs_stb_i(mprj_stb_o_user),
 		.wbs_we_i(mprj_we_o_user),
@@ -659,7 +662,7 @@ module caravel (
         .mgmt_addr(mgmt_addr),
         .mgmt_wdata(mgmt_wdata),
         .mgmt_rdata(mgmt_rdata),
-        // Management RO interface  
+        // Management RO interface
         .mgmt_ena_ro(mgmt_ena_ro),
         .mgmt_addr_ro(mgmt_addr_ro),
         .mgmt_rdata_ro(mgmt_rdata_ro)

--- a/verilog/rtl/chip_io.v
+++ b/verilog/rtl/chip_io.v
@@ -81,33 +81,68 @@ module chip_io(
 	// rails and grounds, and one back-to-back diode which connects
 	// between the first LV clamp ground and any other ground.
 
-    	sky130_ef_io__vddio_hvc_pad mgmt_vddio_hvclamp_pad [1:0] (
+    	sky130_ef_io__vddio_hvc_pad mgmt_vddio_hvclamp_pad[0] (
 		`MGMT_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VDDIO(vddio),
+`endif
+		`HVCLAMP_PINS(vddio, vssio)
+    	);
+
+	// lies in user area 2
+    	sky130_ef_io__vddio_hvc_pad mgmt_vddio_hvclamp_pad[1] (
+		`USER2_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VDDIO(vddio),
+`endif
 		`HVCLAMP_PINS(vddio, vssio)
     	);
 
     	sky130_ef_io__vdda_hvc_pad mgmt_vdda_hvclamp_pad (
 		`MGMT_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VDDA(vdda),
+`endif
 		`HVCLAMP_PINS(vdda, vssa)
     	);
 
     	sky130_ef_io__vccd_lvc_pad mgmt_vccd_lvclamp_pad (
 		`MGMT_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VCCD(vccd),
+`endif
 		`LVCLAMP_PINS(vccd, vssio, vccd, vssd, vssa)
     	);
 
-    	sky130_ef_io__vssio_hvc_pad mgmt_vssio_hvclamp_pad [1:0] (
+    	sky130_ef_io__vssio_hvc_pad mgmt_vssio_hvclamp_pad[0] (
 		`MGMT_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VSSIO(vssio),
+`endif
+		`HVCLAMP_PINS(vddio, vssio)
+    	);
+
+    	sky130_ef_io__vssio_hvc_pad mgmt_vssio_hvclamp_pad[1] (
+		`USER2_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VSSIO(vssio),
+`endif
 		`HVCLAMP_PINS(vddio, vssio)
     	);
 
     	sky130_ef_io__vssa_hvc_pad mgmt_vssa_hvclamp_pad (
 		`MGMT_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VSSA(vssa),
+`endif
 		`HVCLAMP_PINS(vdda, vssa)
     	);
 
     	sky130_ef_io__vssd_lvc_pad mgmt_vssd_lvclmap_pad (
 		`MGMT_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VSSD(vssd),
+`endif
 		`LVCLAMP_PINS(vccd, vssio, vccd, vssd, vssa)
     	);
 
@@ -116,21 +151,33 @@ module chip_io(
 
     	sky130_ef_io__vdda_hvc_pad user1_vdda_hvclamp_pad [1:0] (
 		`USER1_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VDDA(vdda1),
+`endif
 		`HVCLAMP_PINS(vdda1, vssa1)
     	);
 
     	sky130_ef_io__vccd_lvc_pad user1_vccd_lvclamp_pad (
 		`USER1_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VCCD(vccd1),
+`endif
 		`LVCLAMP_PINS(vccd1, vssd1, vccd1, vssd, vssio)
     	);
 
     	sky130_ef_io__vssa_hvc_pad user1_vssa_hvclamp_pad [1:0] (
 		`USER1_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VSSA(vssa1),
+`endif
 		`HVCLAMP_PINS(vdda1, vssa1)
     	);
 
     	sky130_ef_io__vssd_lvc_pad user1_vssd_lvclmap_pad (
 		`USER1_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VSSD(vssd1),
+`endif
 		`LVCLAMP_PINS(vccd1, vssd1, vccd1, vssd, vssio)
     	);
 
@@ -139,39 +186,51 @@ module chip_io(
 
     	sky130_ef_io__vdda_hvc_pad user2_vdda_hvclamp_pad (
 		`USER2_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VDDA(vdda2),
+`endif
 		`HVCLAMP_PINS(vdda2, vssa2)
     	);
 
     	sky130_ef_io__vccd_lvc_pad user2_vccd_lvclamp_pad (
 		`USER2_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VCCD(vccd2),
+`endif
 		`LVCLAMP_PINS(vccd2, vssd2, vccd2, vssd, vssio)
     	);
 
     	sky130_ef_io__vssa_hvc_pad user2_vssa_hvclamp_pad (
 		`USER2_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VSSA(vssa2),
+`endif
 		`HVCLAMP_PINS(vdda2, vssa2)
     	);
 
     	sky130_ef_io__vssd_lvc_pad user2_vssd_lvclmap_pad (
 		`USER2_ABUTMENT_PINS
+`ifdef TOP_ROUTING
+		.VSSD(vssd2),
+`endif
 		`LVCLAMP_PINS(vccd2, vssd2, vccd2, vssd, vssio)
     	);
 
 	wire [2:0] dm_all =
     		{gpio_mode1_core, gpio_mode1_core, gpio_mode0_core};
-	wire[2:0] flash_io0_mode = 
+	wire[2:0] flash_io0_mode =
 		{flash_io0_ieb_core, flash_io0_ieb_core, flash_io0_oeb_core};
-	wire[2:0] flash_io1_mode = 
+	wire[2:0] flash_io1_mode =
 		{flash_io1_ieb_core, flash_io1_ieb_core, flash_io1_oeb_core};
 
 	// Management clock input pad
-	`INPUT_PAD(clock, clock_core); 	    
+	`INPUT_PAD(clock, clock_core);
 
     	// Management GPIO pad
 	`INOUT_PAD(
 		gpio, gpio_in_core, gpio_out_core,
 		gpio_inenb_core, gpio_outenb_core, dm_all);
-	
+
 	// Management Flash SPI pads
 	`INOUT_PAD(
 		flash_io0, flash_io0_di_core, flash_io0_do_core,
@@ -180,7 +239,7 @@ module chip_io(
 		flash_io1, flash_io1_di_core, flash_io1_do_core,
 		flash_io1_ieb_core, flash_io1_oeb_core, flash_io1_mode);
 
-	`OUTPUT_PAD(flash_csb, flash_csb_core, flash_csb_ieb_core, flash_csb_oeb_core);  
+	`OUTPUT_PAD(flash_csb, flash_csb_core, flash_csb_ieb_core, flash_csb_oeb_core);
 	`OUTPUT_PAD(flash_clk, flash_clk_core, flash_clk_ieb_core, flash_clk_oeb_core);
 
 	// NOTE:  The analog_out pad from the raven chip has been replaced by
@@ -188,6 +247,7 @@ module chip_io(
     	// power-on-reset circuit.  The XRES pad is used for providing a glitch-
     	// free reset.
 
+	wire xresloop;
 	sky130_fd_io__top_xres4v2 resetb_pad (
 		`MGMT_ABUTMENT_PINS 
 		`ifndef	TOP_ROUTING
@@ -208,24 +268,29 @@ module chip_io(
     	);
 
 	// Corner cells (These are overlay cells;  it is not clear what is normally
-    	// supposed to go under them.)  
+    	// supposed to go under them.)
 
-	`ifndef TOP_ROUTING   
 	    sky130_ef_io__corner_pad mgmt_corner [1:0] (
+`ifndef TOP_ROUTING
 		.VSSIO(vssio),
 		.VDDIO(vddio),
 		.VDDIO_Q(vddio_q),
 		.VSSIO_Q(vssio_q),
 		.AMUXBUS_A(analog_a),
 		.AMUXBUS_B(analog_b),
-		.VSSD(vssio),
-		.VSSA(vssio),
+		.VSSD(vssd),
+		.VSSA(vssa),
 		.VSWITCH(vddio),
 		.VDDA(vdda),
 		.VCCD(vccd),
 		.VCCHIB(vccd)
+`else
+		.VCCHIB()
+`endif
+
     	    );
 	    sky130_ef_io__corner_pad user1_corner (
+`ifndef TOP_ROUTING
 		.VSSIO(vssio),
 		.VDDIO(vddio),
 		.VDDIO_Q(vddio_q),
@@ -238,8 +303,12 @@ module chip_io(
 		.VDDA(vdda1),
 		.VCCD(vccd1),
 		.VCCHIB(vccd)
+`else
+		.VCCHIB()
+`endif
     	    );
 	    sky130_ef_io__corner_pad user2_corner (
+`ifndef TOP_ROUTING
 		.VSSIO(vssio),
 		.VDDIO(vddio),
 		.VDDIO_Q(vddio_q),
@@ -252,8 +321,10 @@ module chip_io(
 		.VDDA(vdda2),
 		.VCCD(vccd2),
 		.VCCHIB(vccd)
+`else
+		.VCCHIB()
+`endif
     	    );
-	`endif
 
 	mprj_io mprj_pads(
 		.vddio(vddio),

--- a/verilog/rtl/mprj_io.v
+++ b/verilog/rtl/mprj_io.v
@@ -44,7 +44,7 @@ module mprj_io #(
     wire [`MPRJ_IO_PADS-1:0] loop1_io;
     wire [6:0] no_connect;
 
-    sky130_ef_io__gpiov2_pad  area1_io_pad [AREA1PADS - 1:0] (
+    sky130_ef_io__gpiov2_pad_wrapped  area1_io_pad [AREA1PADS - 1:0] (
 	`USER1_ABUTMENT_PINS
 	`ifndef	TOP_ROUTING
 	    .PAD(io[AREA1PADS - 1:0]),
@@ -75,7 +75,7 @@ module mprj_io #(
 	    .TIE_LO_ESD(loop1_io[AREA1PADS - 1:0])
     );
 
-    sky130_ef_io__gpiov2_pad area2_io_pad [`MPRJ_IO_PADS - AREA1PADS - 1:0] (
+    sky130_ef_io__gpiov2_pad_wrapped area2_io_pad [`MPRJ_IO_PADS - AREA1PADS - 1:0] (
 	`USER2_ABUTMENT_PINS
 	`ifndef	TOP_ROUTING
 	    .PAD(io[`MPRJ_IO_PADS - 1:AREA1PADS]),

--- a/verilog/rtl/pads.v
+++ b/verilog/rtl/pads.v
@@ -60,7 +60,7 @@
 
 `define INPUT_PAD(X,Y) \
 	wire loop_``X; \
-	sky130_ef_io__gpiov2_pad X``_pad ( \
+	sky130_ef_io__gpiov2_pad_wrapped X``_pad ( \
 	`MGMT_ABUTMENT_PINS \
 	`ifndef	TOP_ROUTING \
 		.PAD(X), \
@@ -92,7 +92,7 @@
 
 `define OUTPUT_PAD(X,Y,INPUT_DIS,OUT_EN_N) \
 	wire loop_``X; \
-	sky130_ef_io__gpiov2_pad X``_pad ( \
+	sky130_ef_io__gpiov2_pad_wrapped X``_pad ( \
 	`MGMT_ABUTMENT_PINS \
 	`ifndef	TOP_ROUTING \
 		.PAD(X), \
@@ -123,7 +123,8 @@
 		.TIE_LO_ESD(loop_``X)) 
 
 `define INOUT_PAD(X,Y,Y_OUT,INPUT_DIS,OUT_EN_N,MODE) \
-	sky130_ef_io__gpiov2_pad X``_pad ( \
+	wire loop_``X; \
+	sky130_ef_io__gpiov2_pad_wrapped X``_pad ( \
 	`MGMT_ABUTMENT_PINS \
 	`ifndef	TOP_ROUTING \
 		.PAD(X),\

--- a/verilog/rtl/user_proj_example.v
+++ b/verilog/rtl/user_proj_example.v
@@ -23,6 +23,7 @@
 module user_proj_example #(
     parameter BITS = 32
 )(
+`ifdef USE_POWER_PINS
     inout vdda1,	// User area 1 3.3V supply
     inout vdda2,	// User area 2 3.3V supply
     inout vssa1,	// User area 1 analog ground
@@ -31,6 +32,7 @@ module user_proj_example #(
     inout vccd2,	// User area 2 1.8v supply
     inout vssd1,	// User area 1 digital ground
     inout vssd2,	// User area 2 digital ground
+`endif
 
     // Wishbone Slave ports (WB MI A)
     input wb_clk_i,

--- a/verilog/rtl/user_project_wrapper.v
+++ b/verilog/rtl/user_project_wrapper.v
@@ -17,6 +17,7 @@
 module user_project_wrapper #(
     parameter BITS = 32
 )(
+`ifdef USE_POWER_PINS
     inout vdda1,	// User area 1 3.3V supply
     inout vdda2,	// User area 2 3.3V supply
     inout vssa1,	// User area 1 analog ground
@@ -25,6 +26,7 @@ module user_project_wrapper #(
     inout vccd2,	// User area 2 1.8v supply
     inout vssd1,	// User area 1 digital ground
     inout vssd2,	// User area 2 digital ground
+`endif
 
     // Wishbone Slave ports (WB MI A)
     input wb_clk_i,
@@ -63,6 +65,7 @@ module user_project_wrapper #(
     /*--------------------------------------*/
 
     user_proj_example mprj (
+    `ifdef USE_POWER_PINS
 	.vdda1(vdda1),	// User area 1 3.3V power
 	.vdda2(vdda2),	// User area 2 3.3V power
 	.vssa1(vssa1),	// User area 1 analog ground
@@ -71,6 +74,7 @@ module user_project_wrapper #(
 	.vccd2(vccd2),	// User area 2 1.8V power
 	.vssd1(vssd1),	// User area 1 digital ground
 	.vssd2(vssd2),	// User area 2 digital ground
+    `endif
 
 	// MGMT core clock and reset
 


### PR DESCRIPTION
- use USER2_ABUTMENT_PINS for the second of the vssio and vddio pads
- do core-facing power-to-signal connections using the auto-router
- fix corner pad power connections and keep them for LVS purposes
- add a bunch of missing USE_POWER_PINS guards