### PR TITLE
Define "SIM" to fix sim build errors in user_proj_example

### DIFF
--- a/verilog/dv/caravel/user_proj_example/io_ports/Makefile
+++ b/verilog/dv/caravel/user_proj_example/io_ports/Makefile
@@ -16,7 +16,7 @@ all:  ${PATTERN:=.vcd}
 hex:  ${PATTERN:=.hex}
 
 %.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
+	iverilog -DFUNCTIONAL -DSIM -I $(BEHAVIOURAL_MODELS) \
 	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
 	-o $@ $<
 

--- a/verilog/dv/caravel/user_proj_example/la_test1/Makefile
+++ b/verilog/dv/caravel/user_proj_example/la_test1/Makefile
@@ -16,7 +16,7 @@ all:  ${PATTERN:=.vcd}
 hex:  ${PATTERN:=.hex}
 
 %.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
+	iverilog -DFUNCTIONAL -DSIM -I $(BEHAVIOURAL_MODELS) \
 	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
 	-o $@ $<
 

--- a/verilog/dv/caravel/user_proj_example/la_test2/Makefile
+++ b/verilog/dv/caravel/user_proj_example/la_test2/Makefile
@@ -16,7 +16,7 @@ all:  ${PATTERN:=.vcd}
 hex:  ${PATTERN:=.hex}
 
 %.vvp: %_tb.v %.hex
-	iverilog -DFUNCTIONAL -I $(BEHAVIOURAL_MODELS) \
+	iverilog -DFUNCTIONAL -DSIM -I $(BEHAVIOURAL_MODELS) \
 	-I $(PDK_PATH) -I $(IP_PATH) -I $(RTL_PATH) \
 	-o $@ $<
 


### PR DESCRIPTION
`ifdef SIM` was added to caravel.v but these Makefiles don't define `SIM` at the moment.