### PR TITLE
Discard .note.gnu.build-id sections

### DIFF
--- a/verilog/dv/caravel/sections.lds
+++ b/verilog/dv/caravel/sections.lds
@@ -55,4 +55,9 @@ SECTIONS {
 		. = ALIGN(4);
 		_heap_start = .;
 	} >RAM
+
+	/DISCARD/ :
+	{
+		*(.note.gnu.build-id)
+	}
 }


### PR DESCRIPTION
The .note.gnu.build-id section was causing issues on my toolchain,
it would end up getting inserted at the start of the dumps.