### PR TITLE
Explicitly set script_dir since references expect it to point to the directory containing fixed_wrapper_cfgs.tcl

### DIFF
--- a/openlane/user_project_wrapper_empty/fixed_wrapper_cfgs.tcl
+++ b/openlane/user_project_wrapper_empty/fixed_wrapper_cfgs.tcl
@@ -14,6 +14,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # DON'T TOUCH THE FOLLOWING SECTIONS
+set script_dir [file dirname [file normalize [info script]]]
 
 # This makes sure that the core rings are outside the boundaries
 # of your block.


### PR DESCRIPTION
I'm following the integration flow in caravel_user_project, with the caravel subproject pointing to caravel-lite. I receive an error about the pin_order.tcl file if fixed_wrapper_cfgs.tcl does not set script_dir internally. This PR resolves the issue.

My understanding is that changes to caravel are propagated to caravel-lite. Please let me know if I need to take additional action to get this change made to caravel-lite.

Best Regards,
Matthew

Signed-off-by: Matthew Ballance <matt.ballance@gmail.com>